### PR TITLE
feat(extender): Allow `fallbackOnWD` option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,13 +9,15 @@ export interface ExtendedWebDriver extends webdriver.WebDriver {
   setNetworkConnection: (type: number) => webdriver.promise.Promise<void>;
 }
 
-export function extend(baseDriver: webdriver.WebDriver): ExtendedWebDriver {
+export function extend(baseDriver: webdriver.WebDriver, fallbackOnWD = false): ExtendedWebDriver {
   var extender = new Extender(baseDriver);
   let extendedDriver: ExtendedWebDriver = baseDriver as ExtendedWebDriver;
 
   // Simple commands
-  extendedDriver.getNetworkConnection = SimpleCommands.getNetworkConnection.compile(extender);
-  extendedDriver.setNetworkConnection = SimpleCommands.setNetworkConnection.compile(extender);
+  extendedDriver.getNetworkConnection =
+      SimpleCommands.getNetworkConnection.compile(extender, fallbackOnWD);
+  extendedDriver.setNetworkConnection =
+      SimpleCommands.setNetworkConnection.compile(extender, fallbackOnWD);
 
   return extendedDriver;
 }

--- a/lib/simple_command.ts
+++ b/lib/simple_command.ts
@@ -7,11 +7,23 @@ export class SimpleCommand<T> {
       private name: string, private params: string[], private method: string,
       private path: string) {}
 
-  compile(extender: Extender) {
+  compile(extender: Extender, silentFailure: boolean) {
     let name = this.name;
-    extender.defineCommand(name, this.params, this.method, this.path);
-    return function(...args: any[]): Promise.Promise<T> {
-      return extender.execCommand<T>(name, args);
-    };
+    try {
+      extender.defineCommand(name, this.params, this.method, this.path);
+      return function(...args: any[]): Promise.Promise<T> {
+        return extender.execCommand<T>(name, args);
+      };
+    } catch (e) {
+      if (silentFailure) {
+        return function(...args: any[]) {
+          throw new Error(
+              'Command "' + name + '" could not be extended onto WebDriver instance. ' +
+              'This is generally a result of using `directConnect` in protractor.');
+        };
+      } else {
+        throw e;
+      }
+    }
   }
 }


### PR DESCRIPTION
When `true`, this means that if the WebDriver instance cannot be extended, the extend()
function will simply return the origonal WebDriver instance instead of throwing an error