### PR TITLE
Support latest ChromeDriver commands

### DIFF
--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -147,6 +147,6 @@ export let rotationGesture = new CommandDefinition(
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
 export let sendCommand =
-    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/sendcommand');
+    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
 export let sendCommandAndGetResult = new CommandDefinition<Object>(
-    'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/sendcommandandgetresult');
+    'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/send_command_and_get_result');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -147,8 +147,6 @@ export let rotationGesture = new CommandDefinition(
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
 export let sendCommand =
-    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/c/sendcommand');
+    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/sendcommand');
 export let sendCommandAndGetResult = new CommandDefinition<Object>(
-    'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/c/sendcommandandgetresult');
-export let getAllStyleSheets =
-    new CommandDefinition<Object>('getAllStyleSheets', [], 'GET', '/c/getallstylesheets');
+    'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/sendcommandandgetresult');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -150,3 +150,5 @@ export let sendCommand =
     new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/c/sendcommand');
 export let sendCommandAndGetResult = new CommandDefinition<Object>(
     'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/c/sendcommandandgetresult');
+export let getAllStyleSheets =
+    new CommandDefinition<Object>('getAllStyleSheets', [], 'GET', '/c/getallstylesheets');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -146,3 +146,7 @@ export let rotationGesture = new CommandDefinition(
     });
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
+export let sendCommand =
+    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/c/sendcommand');
+export let sendCommandAndGetResult = new CommandDefinition<any>(
+    'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/c/sendcommandandgetresult');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -148,5 +148,5 @@ export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
 export let sendCommand =
     new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/c/sendcommand');
-export let sendCommandAndGetResult = new CommandDefinition<any>(
+export let sendCommandAndGetResult = new CommandDefinition<Object>(
     'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/c/sendcommandandgetresult');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -147,7 +147,7 @@ export interface ExtendedWebDriver extends WebDriver {
   sendCommand: (cmd: string, params: any) => wdpromise.Promise<void>;
 
   // See TODO
-  sendCommandAndGetResult: (cmd: string, params: any) => wdpromise.Promise<any>;
+  sendCommandAndGetResult: (cmd: string, params: any) => wdpromise.Promise<Object>;
 }
 
 export function extend(baseDriver: WebDriver, fallbackGracefully = false): ExtendedWebDriver {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -142,6 +142,12 @@ export interface ExtendedWebDriver extends WebDriver {
 
   // See https://github.com/webdriverio/webdriverio/blob/v4.6.1/lib/protocol/shake
   shakeDevice: () => wdpromise.Promise<void>;
+
+  // See TODO
+  sendCommand: (cmd: string, params: any) => wdpromise.Promise<void>;
+
+  // See TODO
+  sendCommandAndGetResult: (cmd: string, params: any) => wdpromise.Promise<any>;
 }
 
 export function extend(baseDriver: WebDriver, fallbackGracefully = false): ExtendedWebDriver {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -144,10 +144,13 @@ export interface ExtendedWebDriver extends WebDriver {
   shakeDevice: () => wdpromise.Promise<void>;
 
   // See TODO
-  sendCommand: (cmd: string, params: any) => wdpromise.Promise<void>;
+  sendCommand: (cmd: string, params: Object) => wdpromise.Promise<void>;
 
   // See TODO
-  sendCommandAndGetResult: (cmd: string, params: any) => wdpromise.Promise<Object>;
+  sendCommandAndGetResult: (cmd: string, params: Object) => wdpromise.Promise<Object>;
+
+  // See TODO
+  getAllStyleSheets: () => wdpromise.Promise<Object>;
 }
 
 export function extend(baseDriver: WebDriver, fallbackGracefully = false): ExtendedWebDriver {


### PR DESCRIPTION
ChromeDriver version `2.30` [1] will support 2 new endpoints to send custom commands to the DevTools debugger server:

* `/chromium/send_command`;
* `/chromium/send_command_and_get_result`.

In this PR, I add the support for these new commands to the `webdriver-js-extender`.

[1] https://chromium.googlesource.com/chromium/src/+/711de0efbb675bd2a4a28ec47c9194d8e498e600