### PR TITLE
chore: Fix repository property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/angular/webdriver-js-entender.git"
+    "url": "git://github.com/angular/webdriver-js-extender.git"
   },
   "main": "built/lib/index.js",
   "author": "Sammy Jelin <sjelin@gmail.com>",


### PR DESCRIPTION
Very minor fix, but I noticed that the repo link on NPM was broken.

On a side note, do we want travis to be set up? It looks like we have a `.travis.yml` but no [build](https://travis-ci.org/angular/webdriver-js-extender)