### PR TITLE
Support custom devtools server commands

### DIFF
--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -149,4 +149,5 @@ export let shakeDevice =
 export let sendChromiumCommand =
     new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
 export let sendCommandAndGetResult = new CommandDefinition<Object>(
-    'sendChromiumCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/send_command_and_get_result');
+    'sendChromiumCommandAndGetResult', ['cmd', 'params'], 'POST',
+    '/chromium/send_command_and_get_result');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -147,7 +147,7 @@ export let rotationGesture = new CommandDefinition(
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
 export let sendChromiumCommand =
-    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
-export let sendCommandAndGetResult = new CommandDefinition<Object>(
+    new CommandDefinition<void>('sendChromiumCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
+export let sendChromiumCommandAndGetResult = new CommandDefinition<Object>(
     'sendChromiumCommandAndGetResult', ['cmd', 'params'], 'POST',
     '/chromium/send_command_and_get_result');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -146,8 +146,8 @@ export let rotationGesture = new CommandDefinition(
     });
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
-export let sendChromiumCommand =
-    new CommandDefinition<void>('sendChromiumCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
+export let sendChromiumCommand = new CommandDefinition<void>(
+    'sendChromiumCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
 export let sendChromiumCommandAndGetResult = new CommandDefinition<Object>(
     'sendChromiumCommandAndGetResult', ['cmd', 'params'], 'POST',
     '/chromium/send_command_and_get_result');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -146,7 +146,7 @@ export let rotationGesture = new CommandDefinition(
     });
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
-export let sendCommand =
+export let sendChromiumCommand =
     new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
 export let sendCommandAndGetResult = new CommandDefinition<Object>(
-  'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/send_command_and_get_result');
+    'sendChromiumCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/send_command_and_get_result');

--- a/lib/command_definitions.ts
+++ b/lib/command_definitions.ts
@@ -146,3 +146,7 @@ export let rotationGesture = new CommandDefinition(
     });
 export let shakeDevice =
     new CommandDefinition<void>('shakeDevice', [], 'POST', 'appium/device/shake');
+export let sendCommand =
+    new CommandDefinition<void>('sendCommand', ['cmd', 'params'], 'POST', '/chromium/send_command');
+export let sendCommandAndGetResult = new CommandDefinition<Object>(
+  'sendCommandAndGetResult', ['cmd', 'params'], 'POST', '/chromium/send_command_and_get_result');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -141,6 +141,10 @@ export interface ExtendedWebDriver extends WebDriver {
 
   // See https://github.com/webdriverio/webdriverio/blob/v4.6.1/lib/protocol/shake
   shakeDevice: () => wdpromise.Promise<void>;
+
+  sendCommand: (cmd: string, params: Object) => wdpromise.Promise<void>;
+
+  sendCommandAndGetResult: (cmd: string, params: Object) => wdpromise.Promise<Object>;
 }
 
 export function extend(baseDriver: WebDriver, fallbackGracefully = false): ExtendedWebDriver {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -142,9 +142,9 @@ export interface ExtendedWebDriver extends WebDriver {
   // See https://github.com/webdriverio/webdriverio/blob/v4.6.1/lib/protocol/shake
   shakeDevice: () => wdpromise.Promise<void>;
 
-  sendCommand: (cmd: string, params: Object) => wdpromise.Promise<void>;
+  sendChromiumCommand: (cmd: string, params: Object) => wdpromise.Promise<void>;
 
-  sendCommandAndGetResult: (cmd: string, params: Object) => wdpromise.Promise<Object>;
+  sendChromiumCommandAndGetResult: (cmd: string, params: Object) => wdpromise.Promise<Object>;
 }
 
 export function extend(baseDriver: WebDriver, fallbackGracefully = false): ExtendedWebDriver {

--- a/spec/command_tests/table_spec.ts
+++ b/spec/command_tests/table_spec.ts
@@ -63,7 +63,9 @@ describe('table tests', () => {
     openDeviceNotifications: {},
     rotationGesture: [{params: {x: 0, y: 0, duration: 1, rotation: 180, touchCount: 2}},
         {args: [1,2,3,90,5], params: {x: 1, y: 2, duration: 3, rotation: 90, touchCount: 5}}],
-    shakeDevice: {}
+    shakeDevice: {},
+    sendChromiumCommand: {args: ['DOM.enable', {}]},
+    sendChromiumCommandAndGetResult: {args: ['DOM.enable', {}]}
   }
   function runTestcase(commandName: string) {
     let itName = 'should correctly call "' + commandName + '"';

--- a/spec/mock-server/commands/chromium.ts
+++ b/spec/mock-server/commands/chromium.ts
@@ -1,0 +1,16 @@
+/**
+ * Custom chromium commands
+ *
+ * In this file we define all the custom commands which are part of the chromium API but will probably
+ * never be part of the webdriver spec or JsonWireProtocol.
+ */
+
+import {Command} from 'selenium-mock';
+import {ChromiumCommandList} from '../interfaces';
+import {noopFactory as noop} from './helpers';
+
+export let chromium = {
+  sendChromiumCommand: noop('chromium/send_command'),
+  sendChromiumCommandAndGetResult: noop('chromium/send_command_and_get_result')
+} as ChromiumCommandList;
+

--- a/spec/mock-server/commands/index.ts
+++ b/spec/mock-server/commands/index.ts
@@ -6,6 +6,7 @@ import {Command} from 'selenium-mock';
 import {SessionCommandList, ElementCommandList, Session} from '../interfaces';
 import {noopFactory as noop, getterFactory as getter, setterFactory as setter, constFactory} from './helpers';
 import {appium} from './appium';
+import {chromium} from './chromium';
 import {storageFactory} from './storage';
 
 export let session = {
@@ -13,6 +14,7 @@ export let session = {
   sessionStorage: storageFactory('session'),
   localStorage: storageFactory('local'),
   appium: appium,
+  chromium: chromium,
 } as SessionCommandList;
 
 session.currentContext = getter('context', 'currentContext');
@@ -65,3 +67,8 @@ session.performMultiAction = noop('touch/multi/perform');
 session.performTouchAction = noop('touch/perform');
 
 session.element.elementIdLocationInView = constFactory('GET', '/element/:id/location_in_view', {x: 0, y: 0});
+
+/**
+session.sendChromiumCommand = noop('chromium/send_command');
+session.sendChromiumCommandAndGetResult = noop('chromium/send_command_and_get_result');
+*/

--- a/spec/mock-server/commands/index.ts
+++ b/spec/mock-server/commands/index.ts
@@ -67,8 +67,3 @@ session.performMultiAction = noop('touch/multi/perform');
 session.performTouchAction = noop('touch/perform');
 
 session.element.elementIdLocationInView = constFactory('GET', '/element/:id/location_in_view', {x: 0, y: 0});
-
-/**
-session.sendChromiumCommand = noop('chromium/send_command');
-session.sendChromiumCommandAndGetResult = noop('chromium/send_command_and_get_result');
-*/

--- a/spec/mock-server/interfaces.ts
+++ b/spec/mock-server/interfaces.ts
@@ -93,6 +93,11 @@ export interface AppiumCommandList extends CommandList {
   device: AppiumDeviceCommandList;
 }
 
+export interface ChromiumCommandList extends CommandList {
+  sendChromiumCommand: Command<Session>;
+  sendChromiumCommandAndGetResult: Command<Session>;
+}
+
 // Commands which run against a particular webdriver session (as opposed to the whole server).
 export interface SessionCommandList extends CommandList {
   currentContext: Command<Session>;
@@ -124,4 +129,5 @@ export interface SessionCommandList extends CommandList {
   sessionStorage: StorageCommandList;
   localStorage: StorageCommandList;
   appium: AppiumCommandList;
+  chromium: ChromiumCommandList;
 }


### PR DESCRIPTION
ChromeDriver version `2.30` [1] will support 2 new endpoints to send custom commands to the DevTools debugger server:

* `/chromium/send_command`;
* `/chromium/send_command_and_get_result`.

In this PR, I add the support for these new commands to the `webdriver-js-extender`.

[1] https://chromium.googlesource.com/chromium/src/+/711de0efbb675bd2a4a28ec47c9194d8e498e600