### PR TITLE
chore(package): Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
     "selenium",
     "appium"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/angular/webdriver-js-entender.git"
-  },
+  "repository": "github:angular/webdriver-js-extender",
   "main": "built/lib/index.js",
   "author": "Sammy Jelin <sjelin@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Closes #22 

This updates the `repository` field using the shorthand in the [npm docs](https://docs.npmjs.com/files/package.json#repository).

@qiyigg if this looks good do you have a moment to walk me through the release process? I've never published this package (or feel free to do it yourself if you'd rather handle all the releases 😄).