### PR TITLE
Prevent copying of apks in `built/`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ var runSpawn = function(done, task, opt_arg) {
 };
 
 gulp.task('copy', function() {
-  return gulp.src(['**/*.apk', 'package.json'])
+  return gulp.src(['!(built/)**/*.apk', 'package.json'])
       .pipe(gulp.dest('built/'));
 });
 


### PR DESCRIPTION
The `webdriver-js-extender@2.1.0` tarball contains an excessively deep
series of `built/` folders:

```bash
$ npm pack webdriver-js-extender
npm http fetch GET 200 https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.1.0.tgz 85ms
npm notice 📦  webdriver-js-extender@2.1.0
npm notice === Tarball Contents ===
npm notice 1.0kB package.json
npm notice 250B  .travis.yml
npm notice 649B  CONTRIBUTING.md
npm notice 1.5kB gulpfile.js
npm notice 1.1kB LICENSE
npm notice 582B  README.md
npm notice 289B  tsconfig.json
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/built/spec/command_tests/totally_real_apk.apk
npm notice 0     built/built/spec/command_tests/totally_real_apk.apk
npm notice 533B  built/lib/command_definition.d.ts
```

This is because the `copy` task will create a new level every time it
copies an apk that is already in `built/`. This patch fixes this issue
by ensuring that apks in `built/` are never copied.